### PR TITLE
Fix bug getting artist

### DIFF
--- a/scripts/getmusicstatus
+++ b/scripts/getmusicstatus
@@ -29,7 +29,7 @@ if [ -z "$output" ]; then
         esac
     fi
 else
-    artist=$(cmus-remote -Q | grep "tag artist")
+    artist=$(cmus-remote -Q | grep "tag artist ")
     artist=${artist//"tag artist "/""}
     title=$(cmus-remote -Q | grep "tag title")
     title=${title//"tag title "/""}


### PR DESCRIPTION
`grep "tag artist"` also picks up `tag artistsort`, but grepping `"tag artist "` gets the line we're looking for