### PR TITLE
Fixed formatting for format_playlist_va in CMUS

### DIFF
--- a/cmus/autosave
+++ b/cmus/autosave
@@ -54,7 +54,7 @@ set dsp.oss.device=
 set follow=false
 set format_current=
 set format_playlist= %-26%a %t%= %d 
-set format_playlist_va= %-21%A %t%= %d 
+set format_playlist_va= %-26%A %t%= %d 
 set format_statusline= %{status} %a - %t %{?show_playback_position?%{position} %{?duration?/ %{duration} }?%{?duration?%{duration} }}- %{total} %{?volume>=0?vol: %{?lvolume!=rvolume?%{lvolume},%{rvolume} ?%{volume} }}%{?stream?buf: %{buffer} }%{?show_current_bitrate & bitrate>=0? %{bitrate} kbps }%= | %1{continue}%1{follow}%1{repeat}%1{shuffle} 
 set format_title=
 set format_trackwin= %t%= %d 


### PR DESCRIPTION
Formatting for format_playlist_va did not match the formatting for format_playlist, which caused some of the text to be misaligned in the playlist views.